### PR TITLE
Refactored exceptions and added logging.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "type": "library",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -5,23 +5,56 @@ declare(strict_types=1);
 namespace Linio\Component\Database\Adapter;
 
 use Linio\Component\Database\Entity\LazyFetch;
+use Linio\Component\Database\Exception\DatabaseConnectionException;
+use Linio\Component\Database\Exception\DatabaseException;
+use Linio\Component\Database\Exception\InvalidQueryException;
 
 interface AdapterInterface
 {
+    /**
+     * @throws DatabaseConnectionException
+     */
     public function __construct(string $driver, array $options, string $role);
 
+    /**
+     * @throws InvalidQueryException
+     * @throws DatabaseException
+     */
     public function fetchAll(string $query, array $params = []): array;
 
+    /**
+     * @throws InvalidQueryException
+     * @throws DatabaseException
+     */
     public function fetchOne(string $query, array $params = []): array;
 
+    /**
+     * @throws InvalidQueryException
+     * @throws DatabaseException
+     */
     public function fetchValue(string $query, array $params = []);
 
+    /**
+     * @throws InvalidQueryException
+     * @throws DatabaseException
+     */
     public function fetchKeyPairs(string $query, array $params = []): array;
 
+    /**
+     * @throws InvalidQueryException
+     * @throws DatabaseException
+     */
     public function fetchColumn(string $query, array $params = [], int $columnIndex = 0): array;
 
+    /**
+     * @throws InvalidQueryException
+     */
     public function fetchLazy(string $query, array $params = []): LazyFetch;
 
+    /**
+     * @throws InvalidQueryException
+     * @throws DatabaseException
+     */
     public function execute(string $query, array $params = []): int;
 
     public function beginTransaction();

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -7,8 +7,9 @@ namespace Linio\Component\Database\Adapter;
 use Linio\Component\Database\Entity\LazyFetch;
 use Linio\Component\Database\Exception\DatabaseConnectionException;
 use Linio\Component\Database\Exception\DatabaseException;
+use Linio\Component\Database\Exception\FetchException;
 use Linio\Component\Database\Exception\InvalidQueryException;
-use RuntimeException;
+use Linio\Component\Database\Exception\TransactionException;
 
 interface AdapterInterface
 {
@@ -19,31 +20,31 @@ interface AdapterInterface
 
     /**
      * @throws InvalidQueryException
-     * @throws DatabaseException
+     * @throws FetchException
      */
     public function fetchAll(string $query, array $params = []): array;
 
     /**
      * @throws InvalidQueryException
-     * @throws DatabaseException
+     * @throws FetchException
      */
     public function fetchOne(string $query, array $params = []): array;
 
     /**
      * @throws InvalidQueryException
-     * @throws DatabaseException
+     * @throws FetchException
      */
     public function fetchValue(string $query, array $params = []);
 
     /**
      * @throws InvalidQueryException
-     * @throws DatabaseException
+     * @throws FetchException
      */
     public function fetchKeyPairs(string $query, array $params = []): array;
 
     /**
      * @throws InvalidQueryException
-     * @throws DatabaseException
+     * @throws FetchException
      */
     public function fetchColumn(string $query, array $params = [], int $columnIndex = 0): array;
 
@@ -54,22 +55,21 @@ interface AdapterInterface
 
     /**
      * @throws InvalidQueryException
-     * @throws DatabaseException
      */
     public function execute(string $query, array $params = []): int;
 
     /**
-     * @throws DatabaseException
+     * @throws TransactionException
      */
     public function beginTransaction();
 
     /**
-     * @throws DatabaseException
+     * @throws TransactionException
      */
     public function commit();
 
     /**
-     * @throws DatabaseException
+     * @throws TransactionException
      */
     public function rollBack();
 
@@ -79,7 +79,7 @@ interface AdapterInterface
     public function getLastInsertId(string $name = null);
 
     /**
-     * @throws RuntimeException support for the database has not been implemented yet
+     * @throws DatabaseException Support for the database has not been implemented yet
      */
     public function escapeValue(string $value);
 }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -8,6 +8,7 @@ use Linio\Component\Database\Entity\LazyFetch;
 use Linio\Component\Database\Exception\DatabaseConnectionException;
 use Linio\Component\Database\Exception\DatabaseException;
 use Linio\Component\Database\Exception\InvalidQueryException;
+use RuntimeException;
 
 interface AdapterInterface
 {
@@ -57,13 +58,28 @@ interface AdapterInterface
      */
     public function execute(string $query, array $params = []): int;
 
+    /**
+     * @throws DatabaseException
+     */
     public function beginTransaction();
 
+    /**
+     * @throws DatabaseException
+     */
     public function commit();
 
+    /**
+     * @throws DatabaseException
+     */
     public function rollBack();
 
+    /**
+     * @throws DatabaseException
+     */
     public function getLastInsertId(string $name = null);
 
+    /**
+     * @throws RuntimeException support for the database has not been implemented yet
+     */
     public function escapeValue(string $value);
 }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -76,10 +76,10 @@ interface AdapterInterface
     /**
      * @throws DatabaseException
      */
-    public function getLastInsertId(string $name = null);
+    public function getLastInsertId(string $name = null): string;
 
     /**
      * @throws DatabaseException Support for the database has not been implemented yet
      */
-    public function escapeValue(string $value);
+    public function escapeValue(string $value): string;
 }

--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -12,6 +12,7 @@ use Linio\Component\Database\Exception\InvalidQueryException;
 use PDO;
 use PDOException;
 use PDOStatement;
+use RuntimeException;
 
 class PdoAdapter implements AdapterInterface
 {
@@ -171,33 +172,64 @@ class PdoAdapter implements AdapterInterface
         return $stmt;
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function beginTransaction()
     {
-        $this->pdo->beginTransaction();
+        try {
+            $this->pdo->beginTransaction();
+        } catch (PDOException $exception) {
+            throw new DatabaseException($exception->getMessage(), $exception->getCode(), $exception);
+        }
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function commit()
     {
-        $this->pdo->commit();
+        try {
+            $this->pdo->commit();
+        } catch (PDOException $exception) {
+            throw new DatabaseException($exception->getMessage(), $exception->getCode(), $exception);
+        }
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function rollBack()
     {
-        $this->pdo->rollBack();
+        try {
+            $this->pdo->rollBack();
+        } catch (PDOException $exception) {
+            throw new DatabaseException($exception->getMessage(), $exception->getCode(), $exception);
+        }
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function getLastInsertId(string $name = null)
     {
-        return $this->pdo->lastInsertId($name);
+        try {
+            return $this->pdo->lastInsertId($name);
+        } catch (PDOException $exception) {
+            throw new DatabaseException($exception->getMessage(), $exception->getCode(), $exception);
+        }
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function escapeValue(string $value): string
     {
         switch ($this->driver) {
             case DatabaseManager::DRIVER_MYSQL:
                 return str_replace(['\\', "\0", "\n", "\r", "'", '"', "\x1a"], ['\\\\', '\\0', '\\n', '\\r', "\\'", '\\"', '\\Z'], $value);
             default:
-                throw new \RuntimeException('Method not yet implemented for this database');
+                throw new RuntimeException('Method not yet implemented for this database');
         }
     }
 

--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -25,6 +25,9 @@ class PdoAdapter implements AdapterInterface
      */
     protected $driver;
 
+    /**
+     * @throws DatabaseConnectionException
+     */
     public function __construct(string $driver, array $options, string $role)
     {
         $this->driver = $driver;
@@ -32,6 +35,7 @@ class PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @throws InvalidQueryException
      * @throws DatabaseException
      */
     public function fetchAll(string $query, array $params = []): array
@@ -47,6 +51,7 @@ class PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @throws InvalidQueryException
      * @throws DatabaseException
      */
     public function fetchOne(string $query, array $params = []): array
@@ -66,6 +71,7 @@ class PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @throws InvalidQueryException
      * @throws DatabaseException
      */
     public function fetchValue(string $query, array $params = [])
@@ -90,6 +96,7 @@ class PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @throws InvalidQueryException
      * @throws DatabaseException
      */
     public function fetchKeyPairs(string $query, array $params = []): array
@@ -105,6 +112,7 @@ class PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @throws InvalidQueryException
      * @throws DatabaseException
      */
     public function fetchColumn(string $query, array $params = [], int $columnIndex = 0): array
@@ -130,6 +138,7 @@ class PdoAdapter implements AdapterInterface
     }
 
     /**
+     * @throws InvalidQueryException
      * @throws DatabaseException
      */
     public function execute(string $query, array $params = []): int

--- a/src/Adapter/PdoAdapter.php
+++ b/src/Adapter/PdoAdapter.php
@@ -211,7 +211,7 @@ class PdoAdapter implements AdapterInterface
     /**
      * @throws DatabaseException
      */
-    public function getLastInsertId(string $name = null)
+    public function getLastInsertId(string $name = null): string
     {
         try {
             return $this->pdo->lastInsertId($name);

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -9,6 +9,10 @@ use Linio\Component\Database\Entity\Connection;
 use Linio\Component\Database\Entity\LazyFetch;
 use Linio\Component\Database\Entity\SlaveConnectionCollection;
 use Linio\Component\Database\Exception\DatabaseConnectionException;
+use Linio\Component\Database\Exception\DatabaseException;
+use Linio\Component\Database\Exception\FetchException;
+use Linio\Component\Database\Exception\InvalidQueryException;
+use Linio\Component\Database\Exception\TransactionException;
 
 class DatabaseManager
 {
@@ -85,48 +89,77 @@ class DatabaseManager
         ];
     }
 
+    /**
+     * @throws InvalidQueryException
+     * @throws FetchException
+     */
     public function fetchAll(string $query, array $params = [], bool $forceMasterConnection = false): array
     {
         return $this->getReadAdapter($forceMasterConnection)
             ->fetchAll($query, $params);
     }
 
+    /**
+     * @throws InvalidQueryException
+     * @throws FetchException
+     */
     public function fetchOne(string $query, array $params = [], bool $forceMasterConnection = false): array
     {
         return $this->getReadAdapter($forceMasterConnection)
             ->fetchOne($query, $params);
     }
 
+    /**
+     * @throws InvalidQueryException
+     * @throws FetchException
+     */
     public function fetchValue(string $query, array $params = [], bool $forceMasterConnection = false)
     {
         return $this->getReadAdapter($forceMasterConnection)
             ->fetchValue($query, $params);
     }
 
+    /**
+     * @throws InvalidQueryException
+     * @throws FetchException
+     */
     public function fetchKeyPairs(string $query, array $params = [], bool $forceMasterConnection = false): array
     {
         return $this->getReadAdapter($forceMasterConnection)
             ->fetchKeyPairs($query, $params);
     }
 
+    /**
+     * @throws InvalidQueryException
+     * @throws FetchException
+     */
     public function fetchColumn(string $query, array $params = [], int $columnIndex = 0, bool $forceMasterConnection = false): array
     {
         return $this->getReadAdapter($forceMasterConnection)
             ->fetchColumn($query, $params, $columnIndex);
     }
 
+    /**
+     * @throws InvalidQueryException
+     */
     public function fetchLazy(string $query, array $params = [], bool $forceMasterConnection = false): LazyFetch
     {
         return $this->getReadAdapter($forceMasterConnection)
             ->fetchLazy($query, $params);
     }
 
+    /**
+     * @throws InvalidQueryException
+     */
     public function execute(string $query, array $params = []): int
     {
         return $this->getWriteAdapter()
             ->execute($query, $params);
     }
 
+    /**
+     * @throws TransactionException
+     */
     public function beginTransaction(): bool
     {
         if ($this->hasActiveTransaction) {
@@ -139,6 +172,9 @@ class DatabaseManager
         return true;
     }
 
+    /**
+     * @throws TransactionException
+     */
     public function commit(): bool
     {
         if (!$this->hasActiveTransaction) {
@@ -151,6 +187,9 @@ class DatabaseManager
         return true;
     }
 
+    /**
+     * @throws TransactionException
+     */
     public function rollBack(): bool
     {
         if (!$this->hasActiveTransaction) {
@@ -163,16 +202,25 @@ class DatabaseManager
         return true;
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function getLastInsertId(string $name = null)
     {
         return $this->getWriteAdapter()->getLastInsertId($name);
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function escapeValue(string $value): string
     {
         return $this->getWriteAdapter()->escapeValue($value);
     }
 
+    /**
+     * @throws DatabaseException
+     */
     public function escapeValues(array $values): array
     {
         $escapedValues = [];

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -13,6 +13,8 @@ use Linio\Component\Database\Exception\DatabaseException;
 use Linio\Component\Database\Exception\FetchException;
 use Linio\Component\Database\Exception\InvalidQueryException;
 use Linio\Component\Database\Exception\TransactionException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class DatabaseManager
 {
@@ -56,11 +58,17 @@ class DatabaseManager
      */
     protected $hasUsedWriteAdapter = false;
 
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
     public function __construct($safeMode = true)
     {
         $this->setAdapterOptions();
         $this->slaveConnections = new SlaveConnectionCollection();
         $this->safeMode = $safeMode;
+        $this->logger = new NullLogger();
     }
 
     public function addConnection(string $driver, array $options, string $role = self::ROLE_MASTER, int $weight = 1): bool
@@ -76,6 +84,11 @@ class DatabaseManager
         }
 
         return true;
+    }
+
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -95,8 +108,13 @@ class DatabaseManager
      */
     public function fetchAll(string $query, array $params = [], bool $forceMasterConnection = false): array
     {
-        return $this->getReadAdapter($forceMasterConnection)
-            ->fetchAll($query, $params);
+        try {
+            return $this->getReadAdapter($forceMasterConnection)->fetchAll($query, $params);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -105,8 +123,13 @@ class DatabaseManager
      */
     public function fetchOne(string $query, array $params = [], bool $forceMasterConnection = false): array
     {
-        return $this->getReadAdapter($forceMasterConnection)
-            ->fetchOne($query, $params);
+        try {
+            return $this->getReadAdapter($forceMasterConnection)->fetchOne($query, $params);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -115,8 +138,13 @@ class DatabaseManager
      */
     public function fetchValue(string $query, array $params = [], bool $forceMasterConnection = false)
     {
-        return $this->getReadAdapter($forceMasterConnection)
-            ->fetchValue($query, $params);
+        try {
+            return $this->getReadAdapter($forceMasterConnection)->fetchValue($query, $params);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -125,8 +153,13 @@ class DatabaseManager
      */
     public function fetchKeyPairs(string $query, array $params = [], bool $forceMasterConnection = false): array
     {
-        return $this->getReadAdapter($forceMasterConnection)
-            ->fetchKeyPairs($query, $params);
+        try {
+            return $this->getReadAdapter($forceMasterConnection)->fetchKeyPairs($query, $params);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -135,8 +168,13 @@ class DatabaseManager
      */
     public function fetchColumn(string $query, array $params = [], int $columnIndex = 0, bool $forceMasterConnection = false): array
     {
-        return $this->getReadAdapter($forceMasterConnection)
-            ->fetchColumn($query, $params, $columnIndex);
+        try {
+            return $this->getReadAdapter($forceMasterConnection)->fetchColumn($query, $params, $columnIndex);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -144,8 +182,13 @@ class DatabaseManager
      */
     public function fetchLazy(string $query, array $params = [], bool $forceMasterConnection = false): LazyFetch
     {
-        return $this->getReadAdapter($forceMasterConnection)
-            ->fetchLazy($query, $params);
+        try {
+            return $this->getReadAdapter($forceMasterConnection)->fetchLazy($query, $params);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -153,8 +196,13 @@ class DatabaseManager
      */
     public function execute(string $query, array $params = []): int
     {
-        return $this->getWriteAdapter()
-            ->execute($query, $params);
+        try {
+            return $this->getWriteAdapter()->execute($query, $params);
+        } catch (DatabaseException $exception) {
+            $this->logQueryException($exception, $query, $params);
+
+            throw $exception;
+        }
     }
 
     /**
@@ -167,7 +215,11 @@ class DatabaseManager
         }
 
         $this->hasActiveTransaction = true;
-        $this->getWriteAdapter()->beginTransaction();
+        try {
+            $this->getWriteAdapter()->beginTransaction();
+        } catch (DatabaseException $exception) {
+            $this->logException($exception);
+        }
 
         return true;
     }
@@ -181,7 +233,12 @@ class DatabaseManager
             return false;
         }
 
-        $this->getWriteAdapter()->commit();
+        try {
+            $this->getWriteAdapter()->commit();
+        } catch (DatabaseException $exception) {
+            $this->logException($exception);
+        }
+
         $this->hasActiveTransaction = false;
 
         return true;
@@ -196,7 +253,12 @@ class DatabaseManager
             return false;
         }
 
-        $this->getWriteAdapter()->rollBack();
+        try {
+            $this->getWriteAdapter()->rollBack();
+        } catch (DatabaseException $exception) {
+            $this->logException($exception);
+        }
+
         $this->hasActiveTransaction = false;
 
         return true;
@@ -207,7 +269,11 @@ class DatabaseManager
      */
     public function getLastInsertId(string $name = null)
     {
-        return $this->getWriteAdapter()->getLastInsertId($name);
+        try {
+            return $this->getWriteAdapter()->getLastInsertId($name);
+        } catch (DatabaseException $exception) {
+            $this->logException($exception);
+        }
     }
 
     /**
@@ -215,7 +281,11 @@ class DatabaseManager
      */
     public function escapeValue(string $value): string
     {
-        return $this->getWriteAdapter()->escapeValue($value);
+        try {
+            return $this->getWriteAdapter()->escapeValue($value);
+        } catch (DatabaseException $exception) {
+            $this->logException($exception);
+        }
     }
 
     /**
@@ -311,5 +381,25 @@ class DatabaseManager
         $this->hasUsedWriteAdapter = true;
 
         return $this->masterConnection->getAdapter();
+    }
+
+    protected function logQueryException(DatabaseException $exception, string $query, array $params)
+    {
+        $message = sprintf('A database exception occurred [%s]', $exception->getMessage());
+
+        $this->logger->critical($message, [
+            'exception' => $exception,
+            'query' => $query,
+            'parameters' => $params,
+        ]);
+    }
+
+    protected function logException(DatabaseException $exception)
+    {
+        $message = sprintf('A database exception occurred [%s]', $exception->getMessage());
+
+        $this->logger->critical($message, [
+            'exception' => $exception,
+        ]);
     }
 }

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -267,7 +267,7 @@ class DatabaseManager
     /**
      * @throws DatabaseException
      */
-    public function getLastInsertId(string $name = null)
+    public function getLastInsertId(string $name = null): string
     {
         try {
             return $this->getWriteAdapter()->getLastInsertId($name);

--- a/src/Entity/LazyFetch.php
+++ b/src/Entity/LazyFetch.php
@@ -4,26 +4,30 @@ declare(strict_types=1);
 
 namespace Linio\Component\Database\Entity;
 
-use Linio\Component\Database\Exception\DatabaseException;
+use Linio\Component\Database\Exception\FetchException;
+use PDOStatement;
 
 class LazyFetch
 {
     /**
-     * @var \PDOStatement
+     * @var PDOStatement
      */
     protected $pdoStatement;
 
-    public function __construct(\PDOStatement $pdoStatement)
+    public function __construct(PDOStatement $pdoStatement)
     {
         $this->pdoStatement = $pdoStatement;
     }
 
+    /**
+     * @throws FetchException
+     */
     public function fetch(): array
     {
         try {
             $row = $this->pdoStatement->fetch(\PDO::FETCH_ASSOC);
         } catch (\PDOException $e) {
-            throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+            throw new FetchException($e->getMessage(), $e->getCode(), $e);
         }
 
         if ($row === false) {

--- a/src/Exception/DatabaseConnectionException.php
+++ b/src/Exception/DatabaseConnectionException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\Component\Database\Exception;
 
-class DatabaseConnectionException extends \RuntimeException
+class DatabaseConnectionException extends DatabaseException
 {
 }

--- a/src/Exception/FetchException.php
+++ b/src/Exception/FetchException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\Component\Database\Exception;
 
-class InvalidQueryException extends DatabaseException
+class FetchException extends DatabaseException
 {
 }

--- a/src/Exception/TransactionException.php
+++ b/src/Exception/TransactionException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\Component\Database\Exception;
 
-class InvalidQueryException extends DatabaseException
+class TransactionException extends DatabaseException
 {
 }

--- a/tests/Adapter/PdoAdapterTest.php
+++ b/tests/Adapter/PdoAdapterTest.php
@@ -6,6 +6,7 @@ namespace Linio\Component\Database\Adapter;
 
 use Linio\Component\Database\DatabaseManager;
 use Linio\Component\Database\Entity\LazyFetch;
+use Linio\Component\Database\Exception\DatabaseException;
 use Linio\Component\Database\Exception\InvalidQueryException;
 use PDO;
 use PHPUnit\Framework\Assert;
@@ -294,6 +295,18 @@ class PdoAdapterTest extends TestCase
     {
         $this->expectException(InvalidQueryException::class);
         $this->adapter->execute('UPDATE `nop` SET `dept_name` = ? WHERE `dept_no` = ?', ['Test Dept', 'd010']);
+    }
+
+    public function testIsNotCommittingTransactionWithoutCreating()
+    {
+        $this->expectException(DatabaseException::class);
+        $this->adapter->commit();
+    }
+
+    public function testIsNotRollingBackTransactionWithoutCreating()
+    {
+        $this->expectException(DatabaseException::class);
+        $this->adapter->rollBack();
     }
 
     public function testIsGettingLastInsertId()

--- a/tests/Adapter/PdoAdapterTest.php
+++ b/tests/Adapter/PdoAdapterTest.php
@@ -6,8 +6,8 @@ namespace Linio\Component\Database\Adapter;
 
 use Linio\Component\Database\DatabaseManager;
 use Linio\Component\Database\Entity\LazyFetch;
-use Linio\Component\Database\Exception\DatabaseException;
 use Linio\Component\Database\Exception\InvalidQueryException;
+use Linio\Component\Database\Exception\TransactionException;
 use PDO;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -299,13 +299,13 @@ class PdoAdapterTest extends TestCase
 
     public function testIsNotCommittingTransactionWithoutCreating()
     {
-        $this->expectException(DatabaseException::class);
+        $this->expectException(TransactionException::class);
         $this->adapter->commit();
     }
 
     public function testIsNotRollingBackTransactionWithoutCreating()
     {
-        $this->expectException(DatabaseException::class);
+        $this->expectException(TransactionException::class);
         $this->adapter->rollBack();
     }
 


### PR DESCRIPTION
Also made DatabaseException the base exception.

In order to do this new exceptions were created to handle specific cases.

FetchException now covers cases previously covered by DatabaseException when the error occurs during a fetch().

TransactionException now covers cases previously covered by DatabaseException when the error occurs during transaction related commands such as commit() and rollback().
Fixed leaking of PDO exceptions from non fetch methods.
Added missing @throws documentation.